### PR TITLE
fix : corrige value exibido no select

### DIFF
--- a/data/temas.js
+++ b/data/temas.js
@@ -4,8 +4,8 @@ const obj = [
         "corFundo": "#072540",
         "corTextoHeader": "#000000",
         "corTextoComum": "#93c2db",
-        "corTabelaBorda": "9c4668",
-        "corTabelaPreenchimento": "ff8ae2"
+        "corTabelaBorda": "#9c4668",
+        "corTabelaPreenchimento": "#ff8ae2"
     },
     {
         "nome": "Tema Claro",

--- a/mudatema.js
+++ b/mudatema.js
@@ -13,9 +13,15 @@ function getTemas() {
 
 function seta_tema(tema) {
   let objTema = JSON.parse(tema);
-  document.body.style.background = objTema.corFundo;//altera cor de fundo
-  document.querySelector('h1').style.color = objTema.corTextoHeader; //altera cor do texto
-  localStorage.setItem('tema', tema); //salva o tema escolhido em cache
+  document.body.style.background = objTema.corFundo;
+  document.querySelector('h1').style.color = objTema.corTextoHeader;
+  document.body.style.color = objTema.corTextoComum;
+  document.querySelector('table').style.background = objTema.corTabelaPreenchimento;
+  document.querySelectorAll('th').forEach(table => {
+    table.style.borderColor = objTema.corTabelaBorda
+  });
+
+  localStorage.setItem('tema', tema); //salva o tema escolhido no local storage 
 
 }
 
@@ -23,12 +29,15 @@ select.addEventListener('change', function () {
   seta_tema(this.value);
 });
 
-//seta o tema selecionado ao carregar página
+
 function carrega_tema() {
   getTemas();
   const tema = localStorage.getItem('tema');
-  if (tema) {
+  if (tema) {//carrega o tema se ja foi selecionado 
     seta_tema(tema);
     select.value = tema;
+  }
+  else {//carrega o tema que do primeiro value do select
+    seta_tema(select.value);
   }
 }


### PR DESCRIPTION
Quando a página é carregada pela primeira vez, exibe no botao select o texto do primeiro tema do json (hacktoberst 2020) e a cor padrão(tema claro), pois ainda o usuário não selecionou nenhum tema.
Agora corrigindo na função carrega tema, pra exibir sempre o tema que está identificado no select. Por padrão vai ser o primeiro tema que está na ordem do json. 